### PR TITLE
Remove C++ HDF5 bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 # find_package(Python REQUIRED COMPONENTS Development)
 
 # Find HDF5
-find_package(HDF5 REQUIRED COMPONENTS CXX)
+# find_package(HDF5 REQUIRED COMPONENTS CXX)
 
 # Find ZLIB to read gzip files
 if(ENABLE_GZIP)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -72,7 +72,7 @@ CPMAddPackage(
 )
 add_library(yaml::fortran ALIAS yaml-fortran)
 
-CPMFindPackage(
+CPMAddPackage(
     NAME HepMC3
     VERSION 3.2.5
     GIT_REPOSITORY "https://gitlab.cern.ch/hepmc/HepMC3.git"
@@ -89,6 +89,17 @@ CPMFindPackage(
       "HEPMC3_ENABLE_TEST OFF"
       "HEPMC3_INSTALL_INTERFACES OFF"
       "HEPMC3_BUILD_STATIC_LIBS OFF"
+)
+
+CPMAddPackage(
+    NAME HighFive
+    VERSION 2.6.2
+    GITHUB_REPOSITORY BlueBrain/HighFive
+    OPTIONS
+        "HIGHFIVE_USE_BOOST OFF"
+        "HIGHFIVE_EXAMPLES OFF"
+        "HIGHFIVE_BUILD_DOCS OFF"
+        "HIGHFIVE_UNIT_TESTS OFF"
 )
 
 # Install testing framework

--- a/include/Achilles/Interactions.hh
+++ b/include/Achilles/Interactions.hh
@@ -10,7 +10,13 @@
 #include "Achilles/ThreeVector.hh"
 #include "Achilles/Interpolation.hh"
 
-#include "H5Cpp.h"
+// #include "H5Cpp.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#include "highfive/H5Group.hpp"
+#pragma GCC diagnostic pop
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -166,7 +172,7 @@ class GeantInteractions : public Interactions {
     private:
         // Functions
         double CrossSectionAngle(bool, const double&, const double&) const;
-        void LoadData(bool, const H5::Group&);
+        void LoadData(bool, const HighFive::Group&);
 
         // Variables
         std::vector<double> m_theta, m_cdf;

--- a/include/Achilles/Randutils.hh
+++ b/include/Achilles/Randutils.hh
@@ -466,9 +466,9 @@ class auto_seeded : public SeedSeq {
 
         // The heap can vary from run to run as well.
         void* malloc_addr = malloc(sizeof(int));
-        free(malloc_addr);
         auto heap  = hash(malloc_addr);
         auto stack = hash(&malloc_addr);
+        free(malloc_addr);
 
         // Every call, we increment our random int.  We don't care about race
         // conditons.  The more, the merrier.

--- a/src/Achilles/CMakeLists.txt
+++ b/src/Achilles/CMakeLists.txt
@@ -59,7 +59,7 @@ add_library(physics SHARED
     InteractionsFactory.cc
     SpectralFunction.cc
 )
-target_include_directories(physics SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
+# target_include_directories(physics SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
 set(physics_libs "")
 if(ENABLE_GZIP)
     list(APPEND achilles_targets gzstream)
@@ -76,7 +76,7 @@ if(USE_ROOT)
     target_compile_definitions(physics PUBLIC -DUSE_ROOT)
 endif()
 target_link_libraries(physics PRIVATE project_options project_warnings
-                              PUBLIC utilities cuts ${HDF5_CXX_LIBRARIES})
+                      PUBLIC utilities cuts HighFive)
 list(APPEND achilles_targets physics)
 
 add_library(mappers SHARED
@@ -162,7 +162,6 @@ install(TARGETS ${achilles_targets} spdlog yaml-cpp fmt #pybind11 fortran_interf
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${HDF5_INCLUDE_DIRS}
 )
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/achilles
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/Achilles/EventGen.cc
+++ b/src/Achilles/EventGen.cc
@@ -153,7 +153,7 @@ achilles::EventGen::EventGen(const std::string &configFile,
     leptonicProcess.m_mom_map = sherpa -> MomentumMap(leptonicProcess.Ids());
 #else
     // Dummy call to remove unused error
-    shargs.size();
+    (void)shargs;
     leptonicProcess.m_mom_map[0] = leptonicProcess.Ids()[0];
     leptonicProcess.m_mom_map[1] = leptonicProcess.Ids()[1];
     leptonicProcess.m_mom_map[2] = leptonicProcess.Ids()[2];

--- a/src/Achilles/Interactions.cc
+++ b/src/Achilles/Interactions.cc
@@ -16,6 +16,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wnull-dereference"
 #include "highfive/H5File.hpp"
 #pragma GCC diagnostic pop
 

--- a/src/Achilles/Interactions.cc
+++ b/src/Achilles/Interactions.cc
@@ -13,8 +13,13 @@
 #include "Achilles/Utilities.hh"
 #include "Achilles/Random.hh"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#include "highfive/H5File.hpp"
+#pragma GCC diagnostic pop
+
 using namespace achilles;
-using namespace H5;
 
 REGISTER_INTERACTION(GeantInteractions);
 // REGISTER_INTERACTION(GeantInteractionsDt);
@@ -133,50 +138,35 @@ GeantInteractions::GeantInteractions(const YAML::Node& node) {
 
     // Read in the Geant4 hdf5 file and get the np and pp groups
     spdlog::info("GeantInteractions: Loading Geant4 data from {0}.", filename);
-    H5File file(filename, H5F_ACC_RDONLY);
-    Group dataNP(file.openGroup("np")); 
-    Group dataPP(file.openGroup("pp"));
+    HighFive::File file(filename, HighFive::File::ReadOnly);
+    HighFive::Group dataNP(file.getGroup("np")); 
+    HighFive::Group dataPP(file.getGroup("pp"));
 
     // Get the datasets for np and load into local variables
     LoadData(false, dataNP);
 
     // Get the datasets for pp and load into local variables
     LoadData(true, dataPP);
-
-    // Clean-up
-    dataNP.close();
-    dataPP.close();
-    file.close();
-    H5Library::close();
 }
 
-void GeantInteractions::LoadData(bool samePID, const Group& group) {
+void GeantInteractions::LoadData(bool samePID, const HighFive::Group& group) {
     // Load datasets
-    DataSet pcm(group.openDataSet("pcm"));
-    DataSet sigTot(group.openDataSet("sigtot"));
-    DataSet sig(group.openDataSet("sig"));
+    HighFive::DataSet pcm(group.getDataSet("pcm"));
+    HighFive::DataSet sigTot(group.getDataSet("sigtot"));
+    HighFive::DataSet sig(group.getDataSet("sig"));
   
     // Get data for center of momentum
-    DataSpace pcmSpace = pcm.getSpace();
-    std::array<hsize_t, 1> dimPcm{};
-    pcmSpace.getSimpleExtentDims(dimPcm.data(), nullptr);
-    std::vector<double> pcmVec(dimPcm[0]);
-    pcm.read(pcmVec.data(), PredType::NATIVE_DOUBLE, pcmSpace, pcmSpace);
+    std::vector<double> pcmVec;
+    pcm.read(pcmVec);
 
     // Get data for total cross-section
-    DataSpace sigTotSpace = sigTot.getSpace();
-    std::array<hsize_t, 1> dimSigTot{};
-    sigTotSpace.getSimpleExtentDims(dimSigTot.data(), nullptr);
-    std::vector<double> sigTotVec(dimSigTot[0]);
-    sigTot.read(sigTotVec.data(), PredType::NATIVE_DOUBLE, sigTotSpace, sigTotSpace);
+    std::vector<double> sigTotVec;
+    sigTot.read(sigTotVec);
 
     // Get data for angular cross-section
-    DataSpace sigSpace = sig.getSpace();
-    std::array<hsize_t, 2> dimSig{};
-    sigSpace.getSimpleExtentDims(dimSig.data(), nullptr);
-    hsize_t dims = dimSig[0] * dimSig[1];
-    std::vector<double> sigAngular(dims);
-    sig.read(sigAngular.data(), PredType::NATIVE_DOUBLE, sigSpace, sigSpace);
+    auto dims = sig.getDimensions();
+    std::vector<double> sigAngular(dims[0]*dims[1]);
+    sig.read(sigAngular.data());
 
     // Perform interpolation for angles
     achilles::Interp2D interp(pcmVec, m_theta, sigAngular);
@@ -216,14 +206,6 @@ void GeantInteractions::LoadData(bool samePID, const Group& group) {
         m_thetaDistNP.SetData(pcmVec, m_cdf, theta);
         m_thetaDistNP.BicubicSpline();
     }
-
-    // Clean-up
-    pcmSpace.close();
-    sigTotSpace.close();
-    sigSpace.close();
-    pcm.close();
-    sigTot.close();
-    sig.close();
 }
 
 double GeantInteractions::CrossSection(const Particle& particle1,


### PR DESCRIPTION
The C++ HDF5 bindings cause issues on certain systems. Therefore, we switched to using the C bindings through the HighFive library.