### PR TITLE
Changes hepmc3 plugin name. updates NuHepMC writer

### DIFF
--- a/include/plugins/NuHepMC/NuHepMCWriter.hh
+++ b/include/plugins/NuHepMC/NuHepMCWriter.hh
@@ -7,7 +7,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
-#include "HepMC3/WriterAscii.h"
+#include "HepMC3/Writer.h"
 #pragma GCC diagnostic pop
 
 namespace achilles {
@@ -16,8 +16,7 @@ class ProcessGroup;
 
 class NuHepMCWriter : public EventWriter {
   public:
-    NuHepMCWriter(const std::string &filename, bool zipped = true)
-        : file{InitializeStream(filename, zipped)} {}
+    NuHepMCWriter(const std::string &filename, bool zipped = true);
     ~NuHepMCWriter() override = default;
 
     void WriteHeader(const std::string &, const std::vector<ProcessGroup> &) override;
@@ -25,7 +24,8 @@ class NuHepMCWriter : public EventWriter {
 
   private:
     static std::shared_ptr<std::ostream> InitializeStream(const std::string &, bool);
-    HepMC3::WriterAscii file;
+    std::shared_ptr<HepMC3::Writer> file;
+    std::string outfilename;
     achilles::StatsData results;
     static constexpr std::array<int, 3> version{0, 1, 0};
 };

--- a/src/Achilles/CMakeLists.txt
+++ b/src/Achilles/CMakeLists.txt
@@ -97,9 +97,9 @@ add_library(event_gen SHARED
     EventWriter.cc
 )
 if(ACHILLES_ENABLE_HEPMC3)
-list(APPEND achilles_targets hepmc3 nuhepmc)
+list(APPEND achilles_targets ach_hepmc3 nuhepmc)
 target_compile_definitions(physics PUBLIC ACHILLES_ENABLE_HEPMC3)
-target_link_libraries(event_gen PUBLIC hepmc3 nuhepmc)
+target_link_libraries(event_gen PUBLIC ach_hepmc3 nuhepmc)
 endif()
 target_link_libraries(event_gen PRIVATE project_warnings
                                 PUBLIC physics mappers) #fortran_interface

--- a/src/Achilles/CMakeLists.txt
+++ b/src/Achilles/CMakeLists.txt
@@ -97,9 +97,9 @@ add_library(event_gen SHARED
     EventWriter.cc
 )
 if(ACHILLES_ENABLE_HEPMC3)
-list(APPEND achilles_targets ach_hepmc3 nuhepmc)
+list(APPEND achilles_targets AchillesHepMC3 nuhepmc)
 target_compile_definitions(physics PUBLIC ACHILLES_ENABLE_HEPMC3)
-target_link_libraries(event_gen PUBLIC ach_hepmc3 nuhepmc)
+target_link_libraries(event_gen PUBLIC AchillesHepMC3 nuhepmc)
 endif()
 target_link_libraries(event_gen PRIVATE project_warnings
                                 PUBLIC physics mappers) #fortran_interface

--- a/src/plugins/HepMC3/CMakeLists.txt
+++ b/src/plugins/HepMC3/CMakeLists.txt
@@ -1,3 +1,4 @@
-add_library(hepmc3 SHARED HepMC3EventWriter.cc)
-target_link_libraries(hepmc3 PRIVATE project_options
+#had to change this lib name as it was colliding on a linuxFS on hfs+ with libHepMC3.so
+add_library(ach_hepmc3 SHARED HepMC3EventWriter.cc)
+target_link_libraries(ach_hepmc3 PRIVATE project_options
                              PUBLIC HepMC3::All fmt::fmt spdlog::spdlog yaml::cpp utilities physics)

--- a/src/plugins/HepMC3/CMakeLists.txt
+++ b/src/plugins/HepMC3/CMakeLists.txt
@@ -1,4 +1,4 @@
 #had to change this lib name as it was colliding on a linuxFS on hfs+ with libHepMC3.so
-add_library(ach_hepmc3 SHARED HepMC3EventWriter.cc)
-target_link_libraries(ach_hepmc3 PRIVATE project_options
+add_library(AchillesHepMC3 SHARED HepMC3EventWriter.cc)
+target_link_libraries(AchillesHepMC3 PRIVATE project_options
                              PUBLIC HepMC3::All fmt::fmt spdlog::spdlog yaml::cpp utilities physics)

--- a/src/plugins/NuHepMC/CMakeLists.txt
+++ b/src/plugins/NuHepMC/CMakeLists.txt
@@ -1,3 +1,10 @@
+CPMAddPackage(
+  NAME NuHepMC_CPPUtils
+  GIT_TAG main
+  GIT_REPOSITORY "https://github.com/NuHepMC/cpputils.git"
+  OPTIONS "BUILTIN_HEPMC3 OFF"
+)
+
 add_library(nuhepmc SHARED NuHepMCWriter.cc)
 target_link_libraries(nuhepmc PRIVATE project_options
-                               PUBLIC HepMC3::All fmt::fmt spdlog::spdlog yaml::cpp utilities physics)
+                               PUBLIC NuHepMC::CPPUtils fmt::fmt spdlog::spdlog yaml::cpp utilities physics)

--- a/src/plugins/NuHepMC/NuHepMCWriter.cc
+++ b/src/plugins/NuHepMC/NuHepMCWriter.cc
@@ -1,48 +1,61 @@
 #include "plugins/NuHepMC/NuHepMCWriter.hh"
-#include "Achilles/Process.hh"
-#include "HepMC3/GenEvent.h"
-#include "HepMC3/GenParticle.h"
-#include "HepMC3/GenVertex.h"
-#include "gzstream/gzstream.h"
 
 #include "Achilles/Event.hh"
 #include "Achilles/Nucleus.hh"
 #include "Achilles/Particle.hh"
+#include "Achilles/Process.hh"
 #include "Achilles/Version.hh"
+
+#include "gzstream/gzstream.h"
+
+#include "NuHepMC/WriterUtils.hxx"
+#include "NuHepMC/make_writer.hxx"
+
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+
 #include "spdlog/spdlog.h"
 
 using achilles::NuHepMCWriter;
 using namespace HepMC3;
 
-std::shared_ptr<std::ostream> NuHepMCWriter::InitializeStream(const std::string &filename,
-                                                              bool zipped) {
-    std::shared_ptr<std::ostream> output = nullptr;
-    if(zipped) {
-        std::string zipname = filename;
-        if(filename.substr(filename.size() - 3) != ".gz") zipname += std::string(".gz");
-        output = std::make_shared<ogzstream>(zipname.c_str());
-    } else {
-        output = std::make_shared<std::ofstream>(filename);
-    }
+namespace NuHepMC {
+namespace VertexStatus {
+int const Propagation = 22;
+int const Cascade = 23;
+int const Beam = 24;
+int const Decay = 25;
+int const Shower = 26;
+} // namespace VertexStatus
 
-    return output;
-}
+namespace ParticleStatus {
+int const InternalTest = 22;
+int const ExternalTest = 23;
+int const Propagating = 24;
+int const Background = 25;
+int const Captured = 26;
+} // namespace ParticleStatus
+} // namespace NuHepMC
+
+NuHepMCWriter::NuHepMCWriter(const std::string &filename, bool zipped) : outfilename(filename) {}
 
 void NuHepMCWriter::WriteHeader(const std::string &filename,
                                 const std::vector<ProcessGroup> &groups) {
     // Setup generator information
     spdlog::trace("Writing Header");
     auto run = std::make_shared<HepMC3::GenRunInfo>();
-    run->add_attribute("NuHepMC.Version.Major", std::make_shared<HepMC3::IntAttribute>(version[0]));
-    run->add_attribute("NuHepMC.Version.Minor", std::make_shared<HepMC3::IntAttribute>(version[1]));
-    run->add_attribute("NuHepMC.Version.Patch", std::make_shared<HepMC3::IntAttribute>(version[2]));
+    NuHepMC::GR2::WriteVersion(run);
 
     struct HepMC3::GenRunInfo::ToolInfo generator = {std::string("Achilles"),
                                                      std::string(ACHILLES_VERSION),
                                                      std::string("Neutrino event generator")};
     run->tools().push_back(generator);
-    run->add_attribute("Achilles.RunCard", std::make_shared<HepMC3::StringAttribute>(filename));
-    run->set_weight_names({"CV"});
+    NuHepMC::add_attribute(run, "Achilles.RunCard", filename);
+
+    NuHepMC::GR7::SetWeightNames(run, {
+                                          "CV",
+                                      });
 
     // Add all possible processes
     std::vector<int> proc_ids = achilles::AllProcessIDs(groups);
@@ -50,105 +63,108 @@ void NuHepMCWriter::WriteHeader(const std::string &filename,
                        std::make_shared<HepMC3::VectorIntAttribute>(proc_ids));
     auto metadata = achilles::AllProcessMetadata(groups);
     for(const auto data : metadata) {
-        run->add_attribute(fmt::format("NuHepMC.ProcessInfo[{}].Name", data.id),
-                           std::make_shared<HepMC3::StringAttribute>(data.name));
-        run->add_attribute(fmt::format("NuHepMC.ProcessInfo[{}].Description", data.id),
-                           std::make_shared<HepMC3::StringAttribute>(data.description));
-        run->add_attribute(fmt::format("NuHepMC.ProcessInfo[{}].InspireHEP", data.id),
-                           std::make_shared<HepMC3::StringAttribute>(data.inspireHEP));
+        NuHepMC::add_attribute(run, fmt::format("NuHepMC.ProcessInfo[{}].Name", data.id),
+                               data.name);
+        NuHepMC::add_attribute(run, fmt::format("NuHepMC.ProcessInfo[{}].Description", data.id),
+                               data.description);
+        NuHepMC::add_attribute(run, fmt::format("NuHepMC.ProcessInfo[{}].InspireHEP", data.id),
+                               data.inspireHEP);
     }
 
     // List all possible vertex status codes
     // TODO: Make this a conversion from enum of the EventHistory class?
-    std::vector<int> vertex_ids{1, 2, 3, 4, 5};
-    run->add_attribute("NuHepMC.VertexStatusIDs",
-                       std::make_shared<HepMC3::VectorIntAttribute>(vertex_ids));
-    run->add_attribute("NuHepMC.VertexStatusInfo[1].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Primary"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[1].Description",
-                       std::make_shared<HepMC3::StringAttribute>("The main hard interaction"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[2].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Beam"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[2].Description",
-                       std::make_shared<HepMC3::StringAttribute>(
-                           "The vertex defining a beam particle from a flux"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[3].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Nucleus"));
-    run->add_attribute(
-        "NuHepMC.VertexStatusInfo[3].Description",
-        std::make_shared<HepMC3::StringAttribute>("The vertex defining a nucleon in a nucleus"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[4].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Decay"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[4].Description",
-                       std::make_shared<HepMC3::StringAttribute>("A vertex used in a decay chain"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[5].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Shower"));
-    run->add_attribute("NuHepMC.VertexStatusInfo[5].Description",
-                       std::make_shared<HepMC3::StringAttribute>("Vertex used in a shower"));
+    NuHepMC::GR5::WriteVertexStatusIDDefinitions(
+        run, {
+                 {NuHepMC::VertexStatus::Primary, {"Primary", "The main hard interaction"}},
+                 {NuHepMC::VertexStatus::Beam,
+                  {"Beam", "The vertex defining a beam particle from a flux"}},
+                 {NuHepMC::VertexStatus::NucleonSeparation,
+                  {"Nucleus", "The vertex defining a nucleon in a nucleus"}},
+                 {NuHepMC::VertexStatus::Decay, {"Decay", "A vertex used in a decay chain"}},
+                 {NuHepMC::VertexStatus::Shower, {"Shower", "Vertex used in a shower"}},
+                 {NuHepMC::VertexStatus::Propagation, {"Propagation", "Propagation"}},
+                 {NuHepMC::VertexStatus::Cascade, {"Cascade", "Cascade"}},
+             });
 
     // List all possible particle status codes
     // TODO: Make this a conversion from ParticleStatus enum
-    std::vector<int> particle_status{1, 2, 3, 4, 11};
-    run->add_attribute("NuHepMC.ParticleStatusIDs",
-                       std::make_shared<HepMC3::VectorIntAttribute>(particle_status));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[1].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Undecayed physical particle"));
-    run->add_attribute(
-        "NuHepMC.ParticleStatusInfo[1].Description",
-        std::make_shared<HepMC3::StringAttribute>("Final state \"stable\" particles"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[2].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Decayed physical particle"));
-    run->add_attribute(
-        "NuHepMC.ParticleStatusInfo[2].Description",
-        std::make_shared<HepMC3::StringAttribute>("Particle that decayed during the generation"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[3].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Documentation line"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[3].Description",
-                       std::make_shared<HepMC3::StringAttribute>("Internal particle history"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[4].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Incoming beam Particle"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[4].Description",
-                       std::make_shared<HepMC3::StringAttribute>("Incoming beam particle"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[11].Name",
-                       std::make_shared<HepMC3::StringAttribute>("Target particle"));
-    run->add_attribute("NuHepMC.ParticleStatusInfo[11].Description",
-                       std::make_shared<HepMC3::StringAttribute>("Target particle"));
+    NuHepMC::GR6::WriteParticleStatusIDDefinitions(
+        run, {
+                 {NuHepMC::ParticleStatus::UndecayedPhysical,
+                  {"Undecayed physical particle", "Final state \"stable\" particles"}},
+                 {NuHepMC::ParticleStatus::DecayedPhysical,
+                  {"Decayed physical particle", "Particle that decayed during the generation"}},
+                 {NuHepMC::ParticleStatus::DocumentationLine,
+                  {"Documentation line", "Internal particle history"}},
+                 {NuHepMC::ParticleStatus::IncomingBeam,
+                  {"Incoming beam Particle", "Incoming beam Particle"}},
+                 {NuHepMC::ParticleStatus::Target, {"Target particle", "Target particle"}},
+                 {NuHepMC::ParticleStatus::InternalTest, {"InternalTest", "InternalTest"}},
+                 {NuHepMC::ParticleStatus::ExternalTest, {"ExternalTest", "ExternalTest"}},
+                 {NuHepMC::ParticleStatus::Propagating, {"Propagating", "Propagating"}},
+                 {NuHepMC::ParticleStatus::Background, {"Background", "Background"}},
+                 {NuHepMC::ParticleStatus::Captured, {"Captured", "Captured"}},
+             });
 
     // Signal conventions
     // TODO: Make flags to turn on / off different conventions
-    std::vector<std::string> conventions{"G.C.2", "G.C.5", "E.C.1", "E.C.4", "E.C.5"};
-    run->add_attribute("NuHepMC.Conventions",
-                       std::make_shared<HepMC3::VectorStringAttribute>(conventions));
+    NuHepMC::GC1::SetConventions(run,
+                                 {"G.C.2", "G.C.4", "G.C.6", "E.C.1", "E.C.4", "E.C.5", "V.C.1"});
+
+    NuHepMC::GC4::SetCrossSectionUnits(run, "pb", "PerTargetAtom");
 
     // Write out the number of requested events
     // TODO: Read this from run card
     long nevents = 10;
-    run->add_attribute("NuHepMC.Exposure.NEvents",
-                       std::make_shared<HepMC3::LongAttribute>(nevents));
+    NuHepMC::GC2::SetExposureNEvents(run, nevents);
 
-    file.set_run_info(run);
-    file.write_run_info();
+    file = std::shared_ptr<HepMC3::Writer>(NuHepMC::Writer::make_writer(outfilename, run));
     spdlog::trace("Finished writing Header");
 }
 
 int ToNuHepMC(achilles::ParticleStatus status) {
     switch(status) {
     case achilles::ParticleStatus::internal_test:
+        return NuHepMC::ParticleStatus::InternalTest;
     case achilles::ParticleStatus::external_test:
+        return NuHepMC::ParticleStatus::ExternalTest;
     case achilles::ParticleStatus::propagating:
+        return NuHepMC::ParticleStatus::Propagating;
     case achilles::ParticleStatus::background:
+        return NuHepMC::ParticleStatus::Background;
     case achilles::ParticleStatus::captured:
-        return 11;
+        return NuHepMC::ParticleStatus::Captured;
     case achilles::ParticleStatus::initial_state:
-        return 3;
+        return NuHepMC::ParticleStatus::DecayedPhysical;
     case achilles::ParticleStatus::final_state:
     case achilles::ParticleStatus::escaped:
-        return 1;
+        return NuHepMC::ParticleStatus::UndecayedPhysical;
     case achilles::ParticleStatus::decayed:
-        return 2;
+        return NuHepMC::ParticleStatus::DecayedPhysical;
     case achilles::ParticleStatus::beam:
+        return NuHepMC::ParticleStatus::IncomingBeam;
     case achilles::ParticleStatus::target:
-        return 4;
+        return NuHepMC::ParticleStatus::Target;
+    }
+    return -1;
+}
+
+int ToNuHepMC(achilles::EventHistoryNode::StatusCode status) {
+    switch(status) {
+    case achilles::EventHistoryNode::StatusCode::propagation:
+        return NuHepMC::VertexStatus::Propagation;
+    case achilles::EventHistoryNode::StatusCode::cascade:
+        return NuHepMC::VertexStatus::Cascade;
+    case achilles::EventHistoryNode::StatusCode::primary:
+        return NuHepMC::VertexStatus::Primary;
+    case achilles::EventHistoryNode::StatusCode::beam:
+        return NuHepMC::VertexStatus::Beam;
+    case achilles::EventHistoryNode::StatusCode::target:
+        return NuHepMC::VertexStatus::NucleonSeparation;
+    case achilles::EventHistoryNode::StatusCode::decay:
+        return NuHepMC::VertexStatus::Decay;
+    case achilles::EventHistoryNode::StatusCode::shower:
+        return NuHepMC::VertexStatus::Shower;
     }
     return -1;
 }
@@ -176,7 +192,7 @@ struct NuHepMCVisitor : achilles::HistoryVisitor {
         HepMC3::FourVector vertex_pos{position.X(), position.Y(), position.Z(), 0};
         vertex_pos *= to_mm;
         GenVertexPtr vertex = std::make_shared<GenVertex>(vertex_pos);
-        vertex->set_status(static_cast<int>(node->Status()));
+        vertex->set_status(ToNuHepMC(node->Status()));
         for(const auto &part : node->ParticlesIn()) {
             GenParticlePtr particle;
             if(converted.count(part) > 0) {
@@ -219,19 +235,20 @@ void NuHepMCWriter::Write(const achilles::Event &event) {
     // Setup event units
     spdlog::trace("Setting up units");
     NuHepMCVisitor visitor;
-    visitor.evt.set_run_info(file.run_info());
+    visitor.evt.set_run_info(file->run_info());
     visitor.evt.set_event_number(results.Calls());
 
     // Interaction type
-    visitor.evt.add_attribute("ProcID", std::make_shared<IntAttribute>(event.ProcessId()));
+    NuHepMC::ER3::SetProcessID(visitor.evt, event.ProcessId());
 
     // Cross Section
     spdlog::trace("Writing out cross-section");
     auto cross_section = std::make_shared<GenCrossSection>();
     cross_section->set_cross_section(results.Mean(), results.Error(), results.FiniteCalls(),
                                      results.Calls());
-    visitor.evt.add_attribute("GenCrossSection", cross_section);
-    visitor.evt.add_attribute("Flux", std::make_shared<DoubleAttribute>(event.Flux()));
+    visitor.evt.set_cross_section(cross_section);
+
+    NuHepMC::add_attribute(visitor.evt, "Flux", event.Flux());
     visitor.evt.weight("CV") = event.Weight() * nb_to_pb;
 
     // TODO: once we have a detector to simulate interaction location
@@ -239,11 +256,10 @@ void NuHepMCWriter::Write(const achilles::Event &event) {
     // FourVector position{event.Position()};
     HepMC3::FourVector position{0, 0, 0, 0};
     visitor.evt.shift_position_to(position);
-    std::vector<double> labpos = {0, 0, 0, 0};
-    visitor.evt.add_attribute("LabPos", std::make_shared<VectorDoubleAttribute>(labpos));
+    NuHepMC::ER5::SetLabPosition(visitor.evt, {0, 0, 0, 0});
 
     // Walk the history and add to file
     event.History().WalkHistory(visitor);
     // visitor.evt.add_tree(visitor.beamparticles);
-    file.write_event(visitor.evt);
+    file->write_event(visitor.evt);
 }

--- a/src/plugins/NuHepMC/NuHepMCWriter.cc
+++ b/src/plugins/NuHepMC/NuHepMCWriter.cc
@@ -22,19 +22,19 @@ using namespace HepMC3;
 
 namespace NuHepMC {
 namespace VertexStatus {
-int const Propagation = 22;
-int const Cascade = 23;
-int const Beam = 24;
-int const Decay = 25;
-int const Shower = 26;
+static constexpr int Propagation = 22;
+static constexpr int Cascade = 23;
+static constexpr int Beam = 24;
+static constexpr int Decay = 25;
+static constexpr int Shower = 26;
 } // namespace VertexStatus
 
 namespace ParticleStatus {
-int const InternalTest = 22;
-int const ExternalTest = 23;
-int const Propagating = 24;
-int const Background = 25;
-int const Captured = 26;
+static constexpr int InternalTest = 22;
+static constexpr int ExternalTest = 23;
+static constexpr int Propagating = 24;
+static constexpr int Background = 25;
+static constexpr int Captured = 26;
 } // namespace ParticleStatus
 } // namespace NuHepMC
 


### PR DESCRIPTION
- hepmc3 as the cmake library name collides with the real libHepMC3.so on case insensitive systems like HFS+
- Uses NuHepMC::CPPUtils to make the NuHepMC writer more standards compliant