### PR TITLE
updates to latest spdlog and fmt

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,13 +1,13 @@
-CPMFindPackage(
+CPMAddPackage(
     NAME fmt
-    GIT_TAG 7.1.3
+    GIT_TAG 10.1.1
     GITHUB_REPOSITORY fmtlib/fmt
 )
 add_library(fmt::fmt ALIAS fmt)
 
 CPMFindPackage(
     NAME spdlog
-    GIT_TAG "v1.8.5"
+    GIT_TAG "v1.12.0"
     GITHUB_REPOSITORY gabime/spdlog
     OPTIONS
         "SPDLOG_COMPILED_LIB ON"
@@ -42,22 +42,10 @@ CPMAddPackage(
 add_library(yaml::fortran ALIAS yaml-fortran)
 
 CPMAddPackage(
-    NAME HepMC3
-    VERSION 3.2.6
-    GIT_REPOSITORY "https://gitlab.cern.ch/hepmc/HepMC3.git"
-    GIT_TAG 3.2.6
-    OPTIONS
-      "HEPMC3_CXX_STANDARD ${CMAKE_CXX_STANDARD}"
-      "HEPMC3_ENABLE_SEARCH OFF"
-      "HEPMC3_ENABLE_ROOTIO ${ACHILLES_ENABLE_ROOT}"
-      "HEPMC3_ENABLE_PROTOBUFIO OFF"
-      "HEPMC3_ENABLE_PYTHON OFF"
-      "HEPMC3_BUILD_DOCS OFF"
-      "HEPMC3_BUILD_EXAMPLES OFF"
-      "HEPMC3_INSTALL_EXAMPLES OFF"
-      "HEPMC3_ENABLE_TEST OFF"
-      "HEPMC3_INSTALL_INTERFACES OFF"
-      "HEPMC3_BUILD_STATIC_LIBS OFF"
+  NAME NuHepMC_CPPUtils
+  GIT_TAG main
+  GIT_REPOSITORY "https://github.com/NuHepMC/cpputils.git"
+  OPTIONS "BUILTIN_HEPMC3 ON"
 )
 
 CPMAddPackage(

--- a/include/Achilles/ComplexFmt.hh
+++ b/include/Achilles/ComplexFmt.hh
@@ -4,79 +4,81 @@
 #include "fmt/format.h"
 #include <complex>
 
-/// From https://gitlab.com/tesch1/cppduals/blob/master/duals/dual#L1304
-/// std::complex<> Formatter for libfmt https://github.com/fmtlib/fmt
-///
-/// libfmt does not provide a formatter for std::complex<>, although
-/// one is proposed for c++20.  Anyway, at the expense of a k or two,
-/// you can define CPPDUALS_LIBFMT_COMPLEX and get this one.
-///
-/// The standard iostreams formatting of complex numbers is (a,b),
-/// where a and b are the real and imaginary parts.  This formats a
-/// complex number (a+bi) as (a+bi), offering the same formatting
-/// options as the underlying type - with the addition of three
-/// optional format options, only one of which may appear directly
-/// after the ':' in the format spec (before any fill or align): '$'
-/// (the default if no flag is specified), '*', and ','.  The '*' flag
-/// adds a * before the 'i', producing (a+b*i), where a and b are the
-/// formatted value_type values.  The ',' flag simply prints the real
-/// and complex parts separated by a comma (same as iostreams' format).
-/// As a concrete exmple, this formatter can produce either (3+5.4i)
-/// or (3+5.4*i) or (3,5.4) for a complex<double> using the specs {:g}
-/// | {:$g}, {:*g}, or {:,g}, respectively.  (this implementation is a
-/// bit hacky - glad for cleanups).
-///
-template <typename T, typename Char>
-struct fmt::formatter<std::complex<T>, Char> : public fmt::formatter<T, Char> {
-    using base = fmt::formatter<T, Char>;
-    enum style { expr, star, pair } style_ = expr;
-    fmt::detail::dynamic_format_specs<Char> specs_;
-    FMT_CONSTEXPR auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-        using handler_type = fmt::detail::dynamic_specs_handler<format_parse_context>;
-        auto type = fmt::detail::type_constant<T, Char>::value;
-        fmt::detail::specs_checker<handler_type> handler(handler_type(specs_, ctx), type);
+//from https://github.com/fmtlib/fmt/issues/1467
+
+template<typename T, typename Char>
+struct fmt::formatter<std::complex<T>, Char> : public fmt::formatter<T,Char>
+{
+  private:
+    typedef fmt::formatter<T, Char> base;
+    enum style
+    {
+        expr,
+        star,
+        pair
+    } style_ = expr;
+
+    detail::dynamic_format_specs<Char> specs_;
+
+  public:
+    template<typename ParseContext>
+    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char*
+    {
         auto it = ctx.begin();
-        if(it != ctx.end()) {
-            switch(*it) {
-            case '$':
-                style_ = style::expr;
-                ctx.advance_to(++it);
-                break;
-            case '*':
-                style_ = style::star;
-                ctx.advance_to(++it);
-                break;
-            case ',':
-                style_ = style::pair;
-                ctx.advance_to(++it);
-                break;
-            default:
-                break;
+        if (it != ctx.end())
+        {
+            switch (*it)
+            {
+                case '$':
+                    style_ = style::expr;
+                    ctx.advance_to(++it);
+                    break;
+                case '*':
+                    style_ = style::star;
+                    ctx.advance_to(++it);
+                    break;
+                case ',':
+                    style_ = style::pair;
+                    ctx.advance_to(++it);
+                    break;
+                default:
+                    break;
             }
         }
-        parse_format_specs(ctx.begin(), ctx.end(), handler);
-        // todo: fixup alignment
-        return base::parse(ctx);
+
+        auto type = detail::type_constant<T, Char>::value;
+        auto end  = detail::parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, type);
+        if (type == detail::type::char_type)
+            detail::check_char_specs(specs_);
+        return end;
     }
-    template <typename FormatCtx>
-    auto format(const std::complex<T> &x, FormatCtx &ctx) -> decltype(ctx.out()) {
+
+    template<typename FormatContext>
+    FMT_CONSTEXPR auto format(const std::complex<T>& x, FormatContext& ctx) const
+        -> decltype(ctx.out())
+    {
         format_to(ctx.out(), "(");
-        if(style_ == style::pair) {
+        if (style_ == style::pair)
+        {
             base::format(x.real(), ctx);
             format_to(ctx.out(), ",");
             base::format(x.imag(), ctx);
             return format_to(ctx.out(), ")");
         }
-        if(x.real() || !x.imag()) base::format(x.real(), ctx);
-        if(x.imag()) {
-            if(x.real() && x.imag() >= 0 && specs_.sign != sign::plus) format_to(ctx.out(), "+");
+        if (x.real() || !x.imag())
+            base::format(x.real(), ctx);
+        if (x.imag())
+        {
+            if (x.real() && x.imag() >= 0 && specs_.sign != sign::plus)
+                format_to(ctx.out(), "+");
             base::format(x.imag(), ctx);
-            if(style_ == style::star)
+            if (style_ == style::star)
                 format_to(ctx.out(), "*i");
             else
                 format_to(ctx.out(), "i");
-            if(std::is_same<typename std::decay<T>::type, float>::value) format_to(ctx.out(), "f");
-            if(std::is_same<typename std::decay<T>::type, long double>::value)
+            if (std::is_same<typename std::decay<T>::type, float>::value)
+                format_to(ctx.out(), "f");
+            if (std::is_same<typename std::decay<T>::type, long double>::value)
                 format_to(ctx.out(), "l");
         }
         return format_to(ctx.out(), ")");

--- a/include/Achilles/ComplexFmt.hh
+++ b/include/Achilles/ComplexFmt.hh
@@ -4,81 +4,64 @@
 #include "fmt/format.h"
 #include <complex>
 
-//from https://github.com/fmtlib/fmt/issues/1467
+// from https://github.com/fmtlib/fmt/issues/1467
 
-template<typename T, typename Char>
-struct fmt::formatter<std::complex<T>, Char> : public fmt::formatter<T,Char>
-{
+template <typename T, typename Char>
+struct fmt::formatter<std::complex<T>, Char> : public fmt::formatter<T, Char> {
   private:
     typedef fmt::formatter<T, Char> base;
-    enum style
-    {
-        expr,
-        star,
-        pair
-    } style_ = expr;
+    enum style { expr, star, pair } style_ = expr;
 
     detail::dynamic_format_specs<Char> specs_;
 
   public:
-    template<typename ParseContext>
-    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char*
-    {
+    template <typename ParseContext> FMT_CONSTEXPR auto parse(ParseContext &ctx) -> const Char * {
         auto it = ctx.begin();
-        if (it != ctx.end())
-        {
-            switch (*it)
-            {
-                case '$':
-                    style_ = style::expr;
-                    ctx.advance_to(++it);
-                    break;
-                case '*':
-                    style_ = style::star;
-                    ctx.advance_to(++it);
-                    break;
-                case ',':
-                    style_ = style::pair;
-                    ctx.advance_to(++it);
-                    break;
-                default:
-                    break;
+        if(it != ctx.end()) {
+            switch(*it) {
+            case '$':
+                style_ = style::expr;
+                ctx.advance_to(++it);
+                break;
+            case '*':
+                style_ = style::star;
+                ctx.advance_to(++it);
+                break;
+            case ',':
+                style_ = style::pair;
+                ctx.advance_to(++it);
+                break;
+            default:
+                break;
             }
         }
 
         auto type = detail::type_constant<T, Char>::value;
-        auto end  = detail::parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, type);
-        if (type == detail::type::char_type)
-            detail::check_char_specs(specs_);
+        auto end = detail::parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, type);
+        if(type == detail::type::char_type) detail::check_char_specs(specs_);
         return end;
     }
 
-    template<typename FormatContext>
-    FMT_CONSTEXPR auto format(const std::complex<T>& x, FormatContext& ctx) const
-        -> decltype(ctx.out())
-    {
+    template <typename FormatContext>
+    FMT_CONSTEXPR auto format(const std::complex<T> &x, FormatContext &ctx) const
+        -> decltype(ctx.out()) {
         format_to(ctx.out(), "(");
-        if (style_ == style::pair)
-        {
+        if(style_ == style::pair) {
             base::format(x.real(), ctx);
             format_to(ctx.out(), ",");
             base::format(x.imag(), ctx);
             return format_to(ctx.out(), ")");
         }
-        if (x.real() || !x.imag())
-            base::format(x.real(), ctx);
-        if (x.imag())
-        {
-            if (x.real() && x.imag() >= 0 && specs_.sign != sign::plus)
-                format_to(ctx.out(), "+");
+        if(x.real() || !x.imag()) base::format(x.real(), ctx);
+        if(x.imag()) {
+            if(x.real() && x.imag() >= 0 && specs_.sign != sign::plus) format_to(ctx.out(), "+");
             base::format(x.imag(), ctx);
-            if (style_ == style::star)
+            if(style_ == style::star)
                 format_to(ctx.out(), "*i");
             else
                 format_to(ctx.out(), "i");
-            if (std::is_same<typename std::decay<T>::type, float>::value)
-                format_to(ctx.out(), "f");
-            if (std::is_same<typename std::decay<T>::type, long double>::value)
+            if(std::is_same<typename std::decay<T>::type, float>::value) format_to(ctx.out(), "f");
+            if(std::is_same<typename std::decay<T>::type, long double>::value)
                 format_to(ctx.out(), "l");
         }
         return format_to(ctx.out(), ")");

--- a/include/Achilles/Current.hh
+++ b/include/Achilles/Current.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "achilles/ComplexFmt.hh"
+
 #include <array>
 #include <complex>
 #include <stdexcept>

--- a/include/Achilles/Debug.hh
+++ b/include/Achilles/Debug.hh
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "Achilles/FourVector.hh"
+
 #include <string>
+#include <vector>
 
 namespace achilles {
 

--- a/include/Achilles/FormFactor.hh
+++ b/include/Achilles/FormFactor.hh
@@ -8,6 +8,9 @@
 #include <memory>
 
 #include "Achilles/Achilles.hh"
+
+#include "fmt/format.h"
+
 #include "yaml-cpp/node/node.h"
 
 namespace achilles {
@@ -287,5 +290,37 @@ class LovatoFormFactor : public FormFactorImpl, RegistrableFormFactor<LovatoForm
 };
 
 } // namespace achilles
+
+namespace fmt {
+
+template <> struct formatter<achilles::FormFactorInfo::Type> {
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const achilles::FormFactorInfo::Type &ffit, FormatContext &ctx) const {
+        switch(ffit) {
+        case achilles::FormFactorInfo::Type::F1:
+            return format_to(ctx.out(), "F1({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::F2:
+            return format_to(ctx.out(), "F2({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::F1p:
+            return format_to(ctx.out(), "F1p({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::F1n:
+            return format_to(ctx.out(), "F1n({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::F2p:
+            return format_to(ctx.out(), "F2p({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::F2n:
+            return format_to(ctx.out(), "F2n({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::FA:
+            return format_to(ctx.out(), "FA({})", static_cast<int>(ffit));
+        case achilles::FormFactorInfo::Type::FCoh:
+            return format_to(ctx.out(), "FCoh({})", static_cast<int>(ffit));
+        default:
+            return format_to(ctx.out(), "Unknown achilles::FormFactorInfo::Type({}) ",
+                             static_cast<int>(ffit));
+        }
+    }
+};
+} // namespace fmt
 
 #endif

--- a/include/Achilles/LeptonicCurrent.hh
+++ b/include/Achilles/LeptonicCurrent.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Achilles/Current.hh"
+
 #include <complex>
 #include <map>
 #include <vector>

--- a/include/Achilles/NuclearRemnant.hh
+++ b/include/Achilles/NuclearRemnant.hh
@@ -29,4 +29,19 @@ class NuclearRemnant {
 
 } // namespace achilles
 
+namespace fmt {
+
+template <> struct formatter<achilles::NuclearRemnant> {
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext> auto format(const achilles::NuclearRemnant &nucrem, FormatContext &ctx) const {
+        std::stringstream ss;
+        ss << nucrem;
+
+        return format_to(ctx.out(), ss.str());
+    }
+};
+
+} // namespace fmt
+
 #endif

--- a/include/Achilles/NuclearRemnant.hh
+++ b/include/Achilles/NuclearRemnant.hh
@@ -34,7 +34,8 @@ namespace fmt {
 template <> struct formatter<achilles::NuclearRemnant> {
     template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template <typename FormatContext> auto format(const achilles::NuclearRemnant &nucrem, FormatContext &ctx) const {
+    template <typename FormatContext>
+    auto format(const achilles::NuclearRemnant &nucrem, FormatContext &ctx) const {
         std::stringstream ss;
         ss << nucrem;
 

--- a/include/Achilles/Particle.hh
+++ b/include/Achilles/Particle.hh
@@ -313,9 +313,44 @@ template <> struct formatter<achilles::Particle> {
     template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
-    auto format(const achilles::Particle &particle, FormatContext &ctx) {
+    auto format(const achilles::Particle &particle, FormatContext &ctx) const {
         return format_to(ctx.out(), "Particle[{}, {}, {}, {}]", particle.ID(), particle.Status(),
                          particle.Momentum(), particle.Position());
+    }
+};
+
+template <> struct formatter<achilles::ParticleStatus> {
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const achilles::ParticleStatus &status, FormatContext &ctx) const {
+        switch(status) {
+        case achilles::ParticleStatus::internal_test:
+            return format_to(ctx.out(), "internal_test({})", static_cast<int>(status));
+        case achilles::ParticleStatus::external_test:
+            return format_to(ctx.out(), "external_test({})", static_cast<int>(status));
+        case achilles::ParticleStatus::propagating:
+            return format_to(ctx.out(), "propagating({})", static_cast<int>(status));
+        case achilles::ParticleStatus::background:
+            return format_to(ctx.out(), "background({})", static_cast<int>(status));
+        case achilles::ParticleStatus::initial_state:
+            return format_to(ctx.out(), "initial_state({})", static_cast<int>(status));
+        case achilles::ParticleStatus::final_state:
+            return format_to(ctx.out(), "final_state({})", static_cast<int>(status));
+        case achilles::ParticleStatus::escaped:
+            return format_to(ctx.out(), "escaped({})", static_cast<int>(status));
+        case achilles::ParticleStatus::captured:
+            return format_to(ctx.out(), "captured({})", static_cast<int>(status));
+        case achilles::ParticleStatus::decayed:
+            return format_to(ctx.out(), "decayed({})", static_cast<int>(status));
+        case achilles::ParticleStatus::beam:
+            return format_to(ctx.out(), "beam({})", static_cast<int>(status));
+        case achilles::ParticleStatus::target:
+            return format_to(ctx.out(), "target({})", static_cast<int>(status));
+          default:
+            return format_to(ctx.out(), "Unknown achilles::ParticleStatus({}) ",
+                             static_cast<int>(status));
+        }
     }
 };
 

--- a/include/Achilles/Particle.hh
+++ b/include/Achilles/Particle.hh
@@ -347,7 +347,7 @@ template <> struct formatter<achilles::ParticleStatus> {
             return format_to(ctx.out(), "beam({})", static_cast<int>(status));
         case achilles::ParticleStatus::target:
             return format_to(ctx.out(), "target({})", static_cast<int>(status));
-          default:
+        default:
             return format_to(ctx.out(), "Unknown achilles::ParticleStatus({}) ",
                              static_cast<int>(status));
         }

--- a/include/Achilles/ParticleInfo.hh
+++ b/include/Achilles/ParticleInfo.hh
@@ -319,7 +319,7 @@ namespace fmt {
 template <> struct formatter<achilles::PID> {
     template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template <typename FormatContext> auto format(const achilles::PID &pid, FormatContext &ctx) {
+    template <typename FormatContext> auto format(const achilles::PID &pid, FormatContext &ctx) const {
         return format_to(ctx.out(), "{}", pid.AsInt());
     }
 };

--- a/include/Achilles/ParticleInfo.hh
+++ b/include/Achilles/ParticleInfo.hh
@@ -319,7 +319,8 @@ namespace fmt {
 template <> struct formatter<achilles::PID> {
     template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template <typename FormatContext> auto format(const achilles::PID &pid, FormatContext &ctx) const {
+    template <typename FormatContext>
+    auto format(const achilles::PID &pid, FormatContext &ctx) const {
         return format_to(ctx.out(), "{}", pid.AsInt());
     }
 };

--- a/include/Achilles/Poincare.hh
+++ b/include/Achilles/Poincare.hh
@@ -2,6 +2,8 @@
 
 #include "Achilles/FourVector.hh"
 
+#include <vector>
+
 namespace achilles {
 
 class Poincare {

--- a/include/Achilles/ProcessInfo.hh
+++ b/include/Achilles/ProcessInfo.hh
@@ -5,9 +5,9 @@
 #include "fmt/format.h"
 
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -69,7 +69,8 @@ namespace fmt {
 template <> struct formatter<achilles::ProcessInfo> {
     template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template <typename FormatContext> auto format(const achilles::ProcessInfo &procinfo, FormatContext &ctx) const {
+    template <typename FormatContext>
+    auto format(const achilles::ProcessInfo &procinfo, FormatContext &ctx) const {
         std::stringstream ss;
         ss << procinfo;
 

--- a/include/Achilles/ProcessInfo.hh
+++ b/include/Achilles/ProcessInfo.hh
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <sstream>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -62,5 +63,20 @@ template <> struct convert<achilles::ProcessInfo> {
 };
 
 } // namespace YAML
+
+namespace fmt {
+
+template <> struct formatter<achilles::ProcessInfo> {
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext> auto format(const achilles::ProcessInfo &procinfo, FormatContext &ctx) const {
+        std::stringstream ss;
+        ss << procinfo;
+
+        return format_to(ctx.out(), ss.str());
+    }
+};
+
+} // namespace fmt
 
 #endif

--- a/include/Achilles/ThreeVector.hh
+++ b/include/Achilles/ThreeVector.hh
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <iosfwd>
+#include <sstream>
 
 #include "spdlog/fmt/ostr.h"
 
@@ -338,5 +339,20 @@ class ThreeVector {
 ThreeVector operator*(const double &, const ThreeVector &) noexcept;
 
 } // namespace achilles
+
+namespace fmt {
+
+template <> struct formatter<achilles::ThreeVector> {
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const achilles::ThreeVector &vec3, FormatContext &ctx) const {
+        std::stringstream ss;
+        ss << vec3;
+
+        return format_to(ctx.out(), ss.str());
+    }
+};
+} // namespace fmt
 
 #endif // end of include guard: THREEVECTOR_HH


### PR DESCRIPTION
- Moves to using NuHepMC as the main provider of HepMC3 as it needs to track the master head currently.

- This meant updating fmt, which meant updating spdlog.
  - fmt has changed a decent amount in how customer formatters work/are needed, the majority of the changes are adding new formatters or adding const qualifiers to existing one replaced the std::complex formatter with another from the same issue that works with current fmt.