### PR TITLE
Hotfix fortran string

### DIFF
--- a/src/Achilles/fortran/currents_intf.f90
+++ b/src/Achilles/fortran/currents_intf.f90
@@ -80,7 +80,7 @@ subroutine dirac_matrices_in(xmd_in,xmn_in,xmpi_in,xmrho_in,fpind_in,fstar_in,fp
 
     ! Read in delta potential and
     ! set up 1D interpolation
-    open(10, file=find_file('data/rho_0p5.dat', "Interference Model"))
+    open(10, file=trim(find_file('data/rho_0p5.dat', "Interference Model")))
     read(10,*) np_del
     allocate(pdel(np_del),pot_del(np_del))
     do i=1,np_del


### PR DESCRIPTION
There was a string in the fortran modules that did not trim the string. This could cause issues on certain architectures.