### PR TITLE
Fix to allow QE and Intf Fortran models to work with multiple nuclei in 1 run card

### DIFF
--- a/src/Achilles/fortran/currents_intf.f90
+++ b/src/Achilles/fortran/currents_intf.f90
@@ -46,7 +46,7 @@ subroutine dirac_matrices_in(xmd_in,xmn_in,xmpi_in,xmrho_in,fpind_in,fstar_in,fp
     lpi=lpi_in
     lpind=lpind_in
 
-    allocate(up1(nspin_in,4),upp1(nspin_f,4), &
+    if (.not. allocated(up1)) allocate(up1(nspin_in,4),upp1(nspin_f,4), &
             &   ubarp1(nspin_in,4),ubarpp1(nspin_f,4), &
             &   up2(nspin_in,4),upp2(nspin_f,4), &
             &   ubarp2(nspin_in,4),ubarpp2(nspin_f,4))

--- a/src/Achilles/fortran/currents_intf.f90
+++ b/src/Achilles/fortran/currents_intf.f90
@@ -46,10 +46,14 @@ subroutine dirac_matrices_in(xmd_in,xmn_in,xmpi_in,xmrho_in,fpind_in,fstar_in,fp
     lpi=lpi_in
     lpind=lpind_in
 
-    if (.not. allocated(up1)) allocate(up1(nspin_in,4),upp1(nspin_f,4), &
-            &   ubarp1(nspin_in,4),ubarpp1(nspin_f,4), &
-            &   up2(nspin_in,4),upp2(nspin_f,4), &
-            &   ubarp2(nspin_in,4),ubarpp2(nspin_f,4))
+    if (.not. allocated(up1)) allocate(up1(nspin_in,4))
+    if (.not. allocated(upp1)) allocate(upp1(nspin_f,4))
+    if (.not. allocated(ubarp1)) allocate(ubarp1(nspin_in,4))
+    if (.not. allocated(ubarpp1)) allocate(ubarpp1(nspin_f,4)) 
+    if (.not. allocated(up2)) allocate(up2(nspin_in,4))
+    if (.not. allocated(upp2)) allocate(upp2(nspin_f,4))
+    if (.not. allocated(ubarp2)) allocate(ubarp2(nspin_in,4))
+    if (.not. allocated(ubarpp2)) allocate(ubarpp2(nspin_f,4))
 
     sig(:,:,:)=czero
     id(:,:)=czero

--- a/src/Achilles/fortran/currents_opt_v1.f90
+++ b/src/Achilles/fortran/currents_opt_v1.f90
@@ -25,8 +25,10 @@ subroutine dirac_matrices_in(xmn_in)
     
     real*8 :: xmn_in
     xmn=xmn_in
-    if (.not. allocated(up1)) allocate(up1(nspin_in,4),upp1(nspin_f,4), &
-            &   ubarp1(nspin_in,4),ubarpp1(nspin_f,4))
+    if (.not. allocated(up1)) allocate(up1(nspin_in,4))
+    if (.not. allocated(upp1)) allocate(upp1(nspin_f,4))
+    if (.not. allocated(ubarp1)) allocate(ubarp1(nspin_in,4))
+    if (.not. allocated(ubarpp1)) allocate(ubarpp1(nspin_f,4)) 
     sig(:,:,:)=czero
     id(:,:)=czero
     id(1,1)=cone;id(2,2)=cone

--- a/src/Achilles/fortran/currents_opt_v1.f90
+++ b/src/Achilles/fortran/currents_opt_v1.f90
@@ -25,7 +25,7 @@ subroutine dirac_matrices_in(xmn_in)
     
     real*8 :: xmn_in
     xmn=xmn_in
-    allocate(up1(nspin_in,4),upp1(nspin_f,4), &
+    if (.not. allocated(up1)) allocate(up1(nspin_in,4),upp1(nspin_f,4), &
             &   ubarp1(nspin_in,4),ubarpp1(nspin_f,4))
     sig(:,:,:)=czero
     id(:,:)=czero


### PR DESCRIPTION
Added a check to the fortran modules which compute the currents for interference and QE: if the arrays which hold the nucleon spinors have already been allocated, do not allocate them again. 