### PR TITLE
Temporary fix for beam mapper 

### DIFF
--- a/src/Achilles/BeamMapper.cc
+++ b/src/Achilles/BeamMapper.cc
@@ -7,8 +7,7 @@ using achilles::BeamMapper;
 void BeamMapper::GeneratePoint(std::vector<FourVector> &point, const std::vector<double> &rans) {
     auto beam_id = *m_beam->BeamIDs().begin();
     // TODO: Should Masses().back() be the mass of the final state hadronic system or the initial?
-    point[m_idx] =
-        m_beam->Flux(beam_id, rans, (Smin() - Masses()[1]) / (2 * sqrt(Masses()[1])));
+    point[m_idx] = m_beam->Flux(beam_id, rans, (Smin() - Masses()[1]) / (2 * sqrt(Masses()[1])));
 #ifdef ACHILLES_EVENT_DETAILS
     Mapper<FourVector>::Print(__PRETTY_FUNCTION__, point, rans);
 #endif

--- a/src/Achilles/BeamMapper.cc
+++ b/src/Achilles/BeamMapper.cc
@@ -8,7 +8,7 @@ void BeamMapper::GeneratePoint(std::vector<FourVector> &point, const std::vector
     auto beam_id = *m_beam->BeamIDs().begin();
     // TODO: Should Masses().back() be the mass of the final state hadronic system or the initial?
     point[m_idx] =
-        m_beam->Flux(beam_id, rans, (Smin() - Masses().back()) / (2 * sqrt(Masses().back())));
+        m_beam->Flux(beam_id, rans, (Smin() - Masses()[1]) / (2 * sqrt(Masses()[1])));
 #ifdef ACHILLES_EVENT_DETAILS
     Mapper<FourVector>::Print(__PRETTY_FUNCTION__, point, rans);
 #endif
@@ -18,7 +18,7 @@ double BeamMapper::GenerateWeight(const std::vector<FourVector> &point, std::vec
     auto beam_id = *m_beam->BeamIDs().begin();
     // TODO: Should Masses().back() be the mass of the final state hadronic system or the initial?
     auto wgt = m_beam->GenerateWeight(beam_id, point[m_idx], rans,
-                                      (Smin() - Masses().back()) / (2 * sqrt(Masses().back())));
+                                      (Smin() - Masses()[1]) / (2 * sqrt(Masses()[1])));
 #ifdef ACHILLES_EVENT_DETAILS
     Mapper<FourVector>::Print(__PRETTY_FUNCTION__, point, rans);
     spdlog::trace("  Beam weight = {}", wgt);

--- a/src/Achilles/Cascade.cc
+++ b/src/Achilles/Cascade.cc
@@ -773,6 +773,8 @@ bool Cascade::PauliBlocking(const Particle &particle) const noexcept {
 double Cascade::InMediumCorrection(const Particle &particle1, const Particle &particle2) const {
     if(m_medium != InMedium::NonRelativistic) return 1;
 
+    if(!particle1.Info().IsNucleon() || !particle2.Info().IsNucleon()) return 1;
+
     auto p1 = particle1.Momentum();
     auto p2 = particle2.Momentum();
     double mass = particle1.Info().Mass();

--- a/src/Achilles/fortran/currents_pi_dcc.f90
+++ b/src/Achilles/fortran/currents_pi_dcc.f90
@@ -114,7 +114,7 @@ subroutine hadr_curr_matrix_el(hid1,hid2,mesid1,has_axial,J_mu)
    endif
 
    !W limits for DCC model
-   if(sqrt(piNinv).lt.1076.957d0.or.sqrt(piNinv).gt.1400.0d0) then
+   if(sqrt(piNinv).lt.1076.957d0.or.sqrt(piNinv).gt.2000.0d0) then
         J_mu(:,:,:) = (0.0d0,0.0d0)
         return
    endif


### PR DESCRIPTION
This PR implements a temporary fix to the beam mapper to allow things to work for the resonance mode. Also increased the max W of the DCC model to 2 GeV (as it should be?) 