### PR TITLE
fix: Resolve bug with Coherent Event History

### DIFF
--- a/src/Achilles/EventHistory.cc
+++ b/src/Achilles/EventHistory.cc
@@ -141,7 +141,8 @@ void EventHistory::UpdateStatuses(const Particles &particles) {
         node = FindNodeIn(part);
         if(node) {
             for(auto &incoming : node->ParticlesIn()) {
-                if(comp(incoming)) incoming.Status() = part.Status();
+                if(comp(incoming) && incoming.Status() != ParticleStatus::target)
+                    incoming.Status() = part.Status();
             }
         }
     }

--- a/src/plugins/NuHepMC/NuHepMCWriter.cc
+++ b/src/plugins/NuHepMC/NuHepMCWriter.cc
@@ -118,8 +118,7 @@ void NuHepMCWriter::WriteHeader(const std::string &filename,
 
     // Signal conventions
     // TODO: Make flags to turn on / off different conventions
-    NuHepMC::GC1::SetConventions(run,
-                                 {"G.C.4", "G.C.6", "E.C.1", "E.C.4", "E.C.5", "V.C.1"});
+    NuHepMC::GC1::SetConventions(run, {"G.C.4", "G.C.6", "E.C.1", "E.C.4", "E.C.5", "V.C.1"});
 
     // TODO: Update to using newer NuHepMC version
     const auto scale = NuHepMC::to_string(NuUnits::Scale::pb);

--- a/src/plugins/NuHepMC/NuHepMCWriter.cc
+++ b/src/plugins/NuHepMC/NuHepMCWriter.cc
@@ -119,11 +119,11 @@ void NuHepMCWriter::WriteHeader(const std::string &filename,
     // Signal conventions
     // TODO: Make flags to turn on / off different conventions
     NuHepMC::GC1::SetConventions(run,
-                                 {"G.C.2", "G.C.4", "G.C.6", "E.C.1", "E.C.4", "E.C.5", "V.C.1"});
+                                 {"G.C.4", "G.C.6", "E.C.1", "E.C.4", "E.C.5", "V.C.1"});
 
     // TODO: Update to using newer NuHepMC version
     const auto scale = NuHepMC::to_string(NuUnits::Scale::pb);
-    const std::string tgtscale = "PerTarget";
+    const std::string tgtscale = "PerAtom";
     NuHepMC::GC4::SetCrossSectionUnits(run, scale, tgtscale);
 
     // Write out the number of requested events


### PR DESCRIPTION
This fixes an issue that if the target particle (i.e. the nucleus) is the same as the struck particle (i.e. the nucleus in the case of coherent) then it changes the status of the particle incorrectly. This feature was added for handling the cascade history within the event history, but it broke the write out of coherent events. This should now be resolved.