### PR TITLE
Nc 12b interference

### DIFF
--- a/src/Achilles/LeptonicCurrent.cc
+++ b/src/Achilles/LeptonicCurrent.cc
@@ -98,9 +98,9 @@ achilles::FFDictionary LeptonicCurrent::GetFormFactor() {
             {FormFactorInfo::Type::F1p, coupl1},    {FormFactorInfo::Type::F1n, -coupl2},
             {FormFactorInfo::Type::F2p, coupl1},    {FormFactorInfo::Type::F2n, -coupl2},
             {FormFactorInfo::Type::FA, coupl2},     {FormFactorInfo::Type::FResV, coupl3},
-            {FormFactorInfo::Type::FResA, coupl3},  {FormFactorInfo::Type::FPiEM, coupl3},
-            {FormFactorInfo::Type::FMecV3, coupl3}, {FormFactorInfo::Type::FMecV4, coupl3},
-            {FormFactorInfo::Type::FMecV5, coupl3}, {FormFactorInfo::Type::FMecA5, coupl3}};
+            {FormFactorInfo::Type::FResA, coupl3},  {FormFactorInfo::Type::FPiEM, (1 - 2*sin2w)*coupl3},
+            {FormFactorInfo::Type::FMecV3, (1 - 2*sin2w)*coupl3}, {FormFactorInfo::Type::FMecV4, (1 - 2*sin2w)*coupl3},
+            {FormFactorInfo::Type::FMecV5, (1 - 2*sin2w)*coupl3}, {FormFactorInfo::Type::FMecA5, coupl3}};
         results[{PID::neutron(), pid}] = {
             {FormFactorInfo::Type::F1n, coupl1},    {FormFactorInfo::Type::F1p, -coupl2},
             {FormFactorInfo::Type::F2n, coupl1},    {FormFactorInfo::Type::F2p, -coupl2},

--- a/src/Achilles/fortran/currents_intf.f90
+++ b/src/Achilles/fortran/currents_intf.f90
@@ -27,6 +27,7 @@ module dirac_matrices_intf
     real*8, private, save :: xmd,xmn,xmpi,xmrho,w
     type(interp1d), private, save:: interp
     real*8, private, allocatable :: pdel(:),pot_del(:)
+    logical, private, save :: NC
 contains
 
 subroutine dirac_matrices_in(xmd_in,xmn_in,xmpi_in,xmrho_in,fpind_in,fstar_in,fpinn2_in,ga_in,lpi_in,lpind_in)
@@ -170,12 +171,14 @@ subroutine define_spinors()
     return
 end subroutine
 
-subroutine current_init(p1_in,p2_in,pp1_in,pp2_in,q_in,nuc1_pid_in,nuc1_pid_out,nuc2_pid_in,has_axial_in)
+subroutine current_init(p1_in,p2_in,pp1_in,pp2_in,q_in,nuc1_pid_in,nuc1_pid_out,nuc2_pid_in,has_axial_in,NC_in)
     implicit none
     integer*4 :: i
     integer*8 :: nuc1_pid_in,nuc1_pid_out,nuc2_pid_in
     real*8 ::  p1_in(4),p2_in(4),pp1_in(4),pp2_in(4),q_in(4)
-    logical :: has_axial_in
+    logical :: has_axial_in,NC_in
+
+    NC = NC_in
 
     ! 1 if (anti)neutrinos 0 else
     if(has_axial_in .eqv. .false.) then
@@ -580,7 +583,7 @@ subroutine twobody_del_curr_matrix_el(J_mu)
     enddo
    enddo 
 
-   if(ax.eq.0) then
+   if(ax.eq.0.OR.NC.eqv..true.) then
     cta = IDeltaA_EM(t1,t2,t1p,t2)
     ctb = IDeltaB_EM(t1,t2,t1p,t2)
     ctc = IDeltaC_EM(t1,t2,t1p,t2)
@@ -635,7 +638,7 @@ subroutine twobody_del_curr_matrix_el(J_mu)
         enddo
        enddo
 
-       if(ax.eq.0) then
+       if(ax.eq.0.OR.NC.eqv..true.) then
         cta = IDeltaA_EM(t1,t2,t2,t1p)
         ctb = IDeltaB_EM(t1,t2,t2,t1p)
         ctc = IDeltaC_EM(t1,t2,t2,t1p)
@@ -709,7 +712,7 @@ subroutine twobody_pi_curr_matrix_el(J_mu)
         enddo
        enddo
 
-       if(ax.eq.0) then
+       if(ax.eq.0.OR.NC.eqv..true.) then
            ctf = Ivz(t1,t2,t1p,t2) 
            cts = Ivz(t1,t2,t1p,t2) 
            ctp = Ivz(t1,t2,t1p,t2)
@@ -757,7 +760,7 @@ subroutine twobody_pi_curr_matrix_el(J_mu)
        enddo
 
 
-       if(ax.eq.0) then
+       if(ax.eq.0.OR.NC.eqv..true.) then
            ctf = Ivz(t1,t2,t2,t1p) 
            cts = Ivz(t1,t2,t2,t1p) 
            ctp = Ivz(t1,t2,t2,t1p)

--- a/src/Achilles/fortran/intf_spectral_model.f90
+++ b/src/Achilles/fortran/intf_spectral_model.f90
@@ -146,7 +146,14 @@ contains
         complex(c_double_complex), dimension(2,2, nlorentz) :: J_mu_pi_dir, J_mu_del_dir
         complex(c_double_complex), dimension(2,2, nlorentz) :: J_mu_pi_exc, J_mu_del_exc
         complex(c_double_complex), dimension(2,2, nlorentz) :: J_mu_1b, J_mu
-        logical :: has_axial
+        logical :: has_axial, NC
+
+        NC = .false.
+
+        !NC vs. CC
+        if(ff%lookup("FMecA5").ne.(0.0d0,0.0d0) .and. pids_in(1).eq.pids_out(1)) then
+            NC = .true.
+        endif
 
         ! Differentiate EM from CC & NC
         if(ff%lookup("FMecA5").eq.(0.0d0,0.0d0) .and. pids_in(1).eq.pids_out(1)) then
@@ -164,7 +171,7 @@ contains
         ffa(1)=ff%lookup("FA")
         ffa(2)=ff%lookup("FAP")
 
-        call current_init(p1_4,p2_4,pp1_4,pp2_4,q4,pids_in(1),pids_out(1),pids_spect(1),has_axial)
+        call current_init(p1_4,p2_4,pp1_4,pp2_4,q4,pids_in(1),pids_out(1),pids_spect(1),has_axial,NC)
         call define_spinors()
 
         J_mu = (0.0d0,0.0d0)


### PR DESCRIPTION
Changed NC 12b interference isospin operators to be the same as EM isospin operators. The Vector form factors also change according to arXiv:1810.07647v1. Now NC 12b interference returns correct cross sections. 